### PR TITLE
Translation: "Définir comme alternative" means "Set as an alternative"…

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -6,19 +6,21 @@
 # Corentin Perard <corentin.perard@gmail.com>, 2009.
 # Charles-Antoine Couret <cacouret@wanadoo.fr>, 2009.
 # Thomas Canniot <mrtom@fedoraproject.org>, 2009.
+# Bruno Duyé <brunetton@gmail.com>, 2018.
 msgid ""
 msgstr ""
 "Project-Id-Version: pavucontrol trunk\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-10-14 17:10+0200\n"
-"PO-Revision-Date: 2009-09-19 17:01+0200\n"
+"PO-Revision-Date: 2018-01-09 15:45+0100\n"
 "Last-Translator: Thomas Canniot <mrtom@fedoraproject.org>\n"
 "Language-Team: French <fedora-trans-fr@redhat.com>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Lokalize 1.0\n"
+"X-Generator: Poedit 1.8.11\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: fr\n"
 
 #: ../src/pavucontrol.desktop.in.h:1
 msgid "Adjust the volume level"
@@ -134,7 +136,7 @@ msgstr "Son en sourdine"
 
 #: ../src/pavucontrol.glade.h:30
 msgid "Set as fallback"
-msgstr "Définir comme alternative"
+msgstr "Définir comme défaut"
 
 #: ../src/pavucontrol.glade.h:31
 msgid "Stream Title"


### PR DESCRIPTION
Hi,

Since I'm using `pavucontrol` I'm troubled by this translation, and I had to experiment a little with the help of command line to finaly get that this button sets the sink as the default sink for the active sink type (input, output, etc).

This makes the understanding os the functionality of the button difficult to get.
I think that "définir comme défaut" is well more clear.

PS: I'm French.

Thanks